### PR TITLE
Move input + button into solutionSettings widget

### DIFF
--- a/R/newSolutionSidebarPane.R
+++ b/R/newSolutionSidebarPane.R
@@ -14,16 +14,6 @@ NULL
 #'   This widget is used to control the settings for new solutions.
 #'   Defaults to `paste0(id, "_settings")`.
 #'
-#' @param nameId `character` identifier for the [shiny::textInput()]
-#'   widget to create within the sidebar pane.
-#'   This text input widget is used to specify the name for new solutions.
-#'   Defaults to `paste0(id, "_name")`.
-#'
-#' @param buttonId `character` identifier for the [shiny::actionButton()]
-#'   widget to create within the sidebar pane.
-#'   This button widget is used to create new solutions.
-#'   Defaults to `paste0(id, "_button")`.
-#'
 #' @return A `shiny.tag` object with the sidebar pane.
 #'
 #' @examples
@@ -32,9 +22,7 @@ NULL
 #' @export
 newSolutionSidebarPane <- function(
   id,
-  solutionSettingsId = paste0(id, "_settings"),
-  nameId = paste0(id, "_name"),
-  buttonId = paste0(id, "_button")) {
+  solutionSettingsId = paste0(id, "_settings")) {
   # assert arguments are valid
   assertthat::assert_that(
     ### id
@@ -42,13 +30,7 @@ newSolutionSidebarPane <- function(
     assertthat::noNA(id),
     ### solutionSettingsId
     assertthat::is.string(solutionSettingsId),
-    assertthat::noNA(solutionSettingsId),
-    ### nameId
-    assertthat::noNA(nameId),
-    assertthat::is.string(nameId),
-    ### buttonId
-    assertthat::noNA(buttonId),
-    assertthat::is.string(buttonId))
+    assertthat::noNA(solutionSettingsId))
 
   # create sidebar widget
   ## create sidebar
@@ -60,36 +42,10 @@ newSolutionSidebarPane <- function(
       ### container
       htmltools::tags$div(
         class = "new-solution-pane",
-        ### settings
         htmltools::tags$div(
           class = "widget-container",
           solutionSettingsOutput(solutionSettingsId, height = "100%")
-        ),
-
-        ### footer
-        htmltools::tags$div(
-          class = "new-solution-footer",
-          htmltools::tags$div(
-            class = "new-solution-footer-name",
-            shiny::textInput(
-              nameId, NULL,
-              value = "",
-              width = "120%",
-              placeholder = "name for solution"
-            ),
-          ),
-          htmltools::tags$div(
-            class = "new-solution-footer-button",
-            shinyBS::bsButton(
-              buttonId,
-              label = "Generate solution",
-              icon = NULL,
-              style = "primary",
-              type = "action"
-            )
-          )
         )
-
       )
     )
 

--- a/R/solutionSettings.R
+++ b/R/solutionSettings.R
@@ -30,6 +30,15 @@
 #'
 #' }
 #'
+#' The widget also contains a text box. The server value for this
+#' text box is a `character` string, and it can be queried using
+#' `id_name` where `id` is the argument to `elementId`.
+#'
+#' Additionally, the widget contains a button. The server value for this
+#' button is an `integer` indicating the number of times the button
+#' has been clicked, and it can be queried using `id_button` where
+#' where `id` is the argument to `elementId`.
+#'
 #' @examples
 #' # TODO.
 #'
@@ -120,10 +129,33 @@ solutionSettings_html <- function(id, style, class, ...) {
               htmltools::tags$div(class = "weights")
             )
           )
+        ),
+        ### footer
+        htmltools::tags$div(
+          class = "solution-footer",
+          htmltools::tags$div(
+            class = "solution-footer-name",
+            shiny::textInput(
+              inputId = paste0(id, "_name"),
+              NULL,
+              value = "",
+              width = "100%",
+              placeholder = "name for solution"
+            ),
+          ),
+          htmltools::tags$div(
+            class = "solution-footer-button",
+            shinyBS::bsButton(
+              inputId = paste0(id, "_button"),
+              label = "Generate solution",
+              icon = NULL,
+              style = "primary",
+              type = "action"
+            )
+          )
         )
       )
     )
-
 
   # add HTML template scaffolds for dynamic content
   ## weightFactor

--- a/inst/examples/newSolutionPane/ui.R
+++ b/inst/examples/newSolutionPane/ui.R
@@ -5,9 +5,7 @@ fillPage(
       iconList = list(icon("rocket")),
       newSolutionSidebarPane(
         id = "newSolutionPane",
-        solutionSettingsId = "newSolutionPane_settings",
-        nameId = "newSolutionPane_name",
-        buttonId = "newSolutionPane_button"
+        solutionSettingsId = "newSolutionPane_settings"
       )
     ),
     leafletOutput("map", width = "100%", height = "100%")

--- a/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
@@ -12,24 +12,3 @@
 .new-solution-pane .sidebar-content {
   overflow-y: hidden !important;
 }
-
-/* footer */
-/* -- container*/
-.new-solution-pane .new-solution-footer {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  margin: 0;
-  width: 100%;
-  padding-right: 40px;
-  flex-wrap: wrap;
-  position: absolute;
-  top: 93%;
-  left: 20px;
-}
-
-/* -- items*/
-.new-solution-pane .new-solution-footer .form-group.shiny-input-container {
-  margin-bottom: 0px;
-}

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
@@ -25,7 +25,6 @@
   width: 100%;
   padding-right: 40px;
   flex-wrap: wrap;
-  position: relative;
   position: absolute;
   top: 93%;
   left: 20px;

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
@@ -1,11 +1,4 @@
 /* overall widget */
-/* -- style widget contents */
-.solution-setting {
-  width: 100%;
-  border: 1px var(--border) solid;
-  border-radius: 5px 5px 5px 5px;
-}
-
 /* -- ensure widget doesn't expand past the parent container */
 .solution-settings-container {
   overflow-y: hidden;
@@ -21,12 +14,40 @@
   padding: 0;
 }
 
+/* footer */
+/* -- container*/
+.solution-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0;
+  width: 100%;
+  padding-right: 40px;
+  flex-wrap: wrap;
+  position: relative;
+  position: absolute;
+  top: 93%;
+  left: 20px;
+}
+
+/* -- items*/
+.solution-footer .form-group.shiny-input-container {
+  margin-bottom: 0px;
+}
+
+/* view containers */
+.solution-setting {
+  width: 100%;
+  border: 1px var(--border) solid;
+  border-radius: 5px 5px 5px 5px;
+}
+
 /* -- add disabled mouse cursor to any element with the .disable-mouse class */
 .solution-setting .disable-mouse *:hover {
   cursor: not-allowed;
 }
 
-/* view containers */
 .solution-setting .single-view {
   overflow-y: auto;
   max-height: 150px;

--- a/inst/htmlwidgets/solutionSettings.yaml
+++ b/inst/htmlwidgets/solutionSettings.yaml
@@ -21,7 +21,7 @@ dependencies:
       - utils.js
       - SolutionSettings-class.js
     stylesheet:
-      - solution-setting.css
+      - style.css
 
   - name: solutionSettings-style
     version: 1.0-0

--- a/man/newSolutionSidebarPane.Rd
+++ b/man/newSolutionSidebarPane.Rd
@@ -4,12 +4,7 @@
 \alias{newSolutionSidebarPane}
 \title{New solution sidebar pane}
 \usage{
-newSolutionSidebarPane(
-  id,
-  solutionSettingsId = paste0(id, "_settings"),
-  nameId = paste0(id, "_name"),
-  buttonId = paste0(id, "_button")
-)
+newSolutionSidebarPane(id, solutionSettingsId = paste0(id, "_settings"))
 }
 \arguments{
 \item{id}{\code{character} identifier for the sidebar pane.}
@@ -18,16 +13,6 @@ newSolutionSidebarPane(
 \code{\link[=solutionSettings]{solutionSettings()}} widget to create within the sidebar pane.
 This widget is used to control the settings for new solutions.
 Defaults to \code{paste0(id, "_settings")}.}
-
-\item{nameId}{\code{character} identifier for the \code{\link[shiny:textInput]{shiny::textInput()}}
-widget to create within the sidebar pane.
-This text input widget is used to specify the name for new solutions.
-Defaults to \code{paste0(id, "_name")}.}
-
-\item{buttonId}{\code{character} identifier for the \code{\link[shiny:actionButton]{shiny::actionButton()}}
-widget to create within the sidebar pane.
-This button widget is used to create new solutions.
-Defaults to \code{paste0(id, "_button")}.}
 }
 \value{
 A \code{shiny.tag} object with the sidebar pane.

--- a/man/solutionSettings-widget.Rd
+++ b/man/solutionSettings-widget.Rd
@@ -38,6 +38,15 @@ Available options include: \code{"status"}, \code{"factor"}, or \code{"goal"}.}
 to a \code{theme} or \code{weight}.}
 
 }
+
+The widget also contains a text box. The server value for this
+text box is a \code{character} string, and it can be queried using
+\code{id_name} where \code{id} is the argument to \code{elementId}.
+
+Additionally, the widget contains a button. The server value for this
+button is an \code{integer} indicating the number of times the button
+has been clicked, and it can be queried using \code{id_button} where
+where \code{id} is the argument to \code{elementId}.
 }
 
 \examples{

--- a/tests/testthat/test_sidebar_panes.R
+++ b/tests/testthat/test_sidebar_panes.R
@@ -4,8 +4,7 @@ test_that("newSolutionSidebarPane", {
   # create object
   x <-
     newSolutionSidebarPane(
-      id = "sidebarid", solutionSettingsId = "ssId", nameId = "textId",
-      buttonId = "btnId")
+      id = "sidebarid", solutionSettingsId = "ssId")
   # run tests
   h <- rvest::read_html(as.character(x))
   ## sidebar
@@ -19,14 +18,4 @@ test_that("newSolutionSidebarPane", {
       attr = "class",
       x = rvest::html_elements(h, "#ssId")),
     "solutionSettings html-widget html-widget-output")
-  ## text input
-  expect_length(rvest::html_elements(h, "#textId"), 1)
-  expect_identical(
-    xml2::xml_name(rvest::html_elements(h, "#textId")),
-    "input")
-  ## button
-  expect_length(rvest::html_elements(h, "#btnId"), 1)
-  expect_identical(
-    xml2::xml_name(rvest::html_elements(h, "#btnId")),
-    "button")
 })


### PR DESCRIPTION
This PR moves the text input and button widgets from the `newSolutionSidebarPane` widget into the `solutionSettings` widget. It is intended to implement option 1 as described in PR https://github.com/NCC-CNC/locationmisc/pull/17. Briefly, here's a summary of the main changes:

* The `solutionSettings` widget (and thus the div container with the class `solutionSettings`) will now contain a `solution-footer` div container. The  `solution-footer` container is based on the `new-solution-footer` that was previously in the `newSolutionPane` container.
* The `inst/htmlwidgets/lib/solutionSettings-1.0.0/solution-setting.css` file has been renamed to the  `inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css` for consistency.
* The CSS rules for the footer have been deleted from the `inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css` file and added to the `inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css` file. These rules have been updated to folow the new class name for the div container.
 
With this branch, the DOM for the new solution sidebar pane looks like this:

![screenie](https://user-images.githubusercontent.com/3610005/118919725-2eb1e280-b989-11eb-8913-0a68210be2da.png)

@HanqingZhou, I've created this PR so that it can be merged with the footer branch. If this PR fixes the div re-rodering issue needed to finish off https://github.com/NCC-CNC/locationmisc/pull/17, then please feel free to merge it? Please let me know if this PR doesn't re-order the divs as needed, and I can fix it for you ASAP?