### PR TITLE
Categorical lengend2

### DIFF
--- a/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
@@ -1,7 +1,7 @@
 /* pane */
-/* .sidebar-pane {
-  padding-right: 0px !important;
-} */
+.sidebar-pane {
+  padding-right: 2px !important;
+}
 
 .new-solution-pane {
   margin-top: 3px;

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
@@ -3,7 +3,8 @@
 .solutionSettings {
   height: 100%;
   width: 100%;
-  max-height: 90vh;
+  min-height: 91.5vh;
+  width: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -20,8 +21,12 @@
   display: flex;
 }
 
+.solution-settings .panel-group {
+  margin-bottom: 2px !important;
+}
+
 .solution-settings .panel.panel-default {
-  max-height: 41vh;
+  max-height: 43vh;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
@HanqingZhou, I've been playing around with different ways to reduce the footer spacing and avoid overlap issues. I was thinking one approach might be to implement the container `.solution-settings-container` as a flexbox, and then use flex rules to make sure that the footer is always at bottom of the `.solution-settings-container` container (rather than using using `position: absolute` and `top: 93%`). This seems to work on my browser - what do you think? 

Although this strategy means that we don't have to specify a `top` style for the footer container, it does seem to require specifying a height for the `solutionSettings` container (which I suppose is more ideal, but not perfect)? The only issue I can tell with this approach is that the width of the panels seems to shrink when the panels are minimized - I don't suppose you know of a way to fix this? Perhaps setting one of the flexbox settings for `solution-settings` or `solutionSettings` might fix this?

![flexbox](https://user-images.githubusercontent.com/3610005/119083619-65a0fa80-ba54-11eb-9074-315db247f8ca.png)

I've made this as a PR in case this strategy has a flaw/issue that I'm not aware of and we want to keep the CategoricalLegend branch as is? If you think this strategy might work, please feel free to merge it into the CategoricalLegend branch and change/tweak as needed? If you don't think this approach is going to work, please feel free to ignore this PR. I'm just trying to help :)