### PR TITLE
Show/hide legend and icons for visible checkbox

### DIFF
--- a/R/mapManager-components.R
+++ b/R/mapManager-components.R
@@ -46,9 +46,14 @@ mm_header_component_scaffold <- function(id = uuid::UUIDgenerate()) {
     htmltools::tags$input(
       class = "view-checkbox",
       type = "checkbox"),
-    htmltools::tags$input(
-      class = "visible-checkbox",
-      type = "checkbox"),
+    htmltools::tags$label(
+      class = "visible-container",
+      htmltools::tags$input(
+        class = "visible-checkbox",
+        type = "checkbox"),
+      htmltools::tags$i(class = "fa fa-eye checked"),
+      htmltools::tags$i(class = "fa fa-eye-slash unchecked")
+    ),
     htmltools::tags$label(
       class = "name-label disable-if-inactive"
     )

--- a/R/mapManager.R
+++ b/R/mapManager.R
@@ -36,7 +36,9 @@ mapManager <- function(
     width = width,
     height = height,
     package = "locationmisc",
-    elementId = elementId
+    elementId = elementId,
+    dependencies = c(
+      htmltools::htmlDependencies(shiny::icon("map-marked-alt")))
   )
 }
 

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
@@ -47,10 +47,10 @@ class WeightLayer {
             ".disable-if-inactive");
         if (checked) {
           els.forEach((x) => x.removeAttribute("disabled"));
-          els.forEach((x) => x.removeAttribute("style", "display:none"));
+          that.legend_el.style.display = "block";
         } else {
           els.forEach((x) => x.setAttribute("disabled", ""));
-          els.forEach((x) => x.setAttribute("style", "display:none"));
+          that.legend_el.style.display = "none";
         }
       });
     }

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
@@ -34,11 +34,28 @@ class WeightLayer {
     /// visible
     this.visible_el.checked = initial_visible;
     /// view (i.e. show legend?), defaults to false
-    this.view_el.checked = false;
+    this.view_el.checked = true;
     /// legend
     createLegend(this.legend_el, legend, units);
 
-    // set listeners to update user interfance
+    // set listeners to update user interfance, show/hide legends checkbox
+    if (HTMLWidgets.shinyMode) {
+      this.view_el.addEventListener("change", function () {
+        let checked = this.checked;
+        let els =
+          document.getElementById(id).querySelectorAll(
+            ".disable-if-inactive");
+        if (checked) {
+          els.forEach((x) => x.removeAttribute("disabled"));
+          els.forEach((x) => x.removeAttribute("style", "display:none"));
+        } else {
+          els.forEach((x) => x.setAttribute("disabled", ""));
+          els.forEach((x) => x.setAttribute("style", "display:none"));
+        }
+      });
+    }
+
+    // set listeners to update user interfance, icons for visible checkbox
     /// enable/disable widget on click
     if (HTMLWidgets.shinyMode) {
       this.visible_el.addEventListener("change", function () {
@@ -46,10 +63,21 @@ class WeightLayer {
         let els =
           document.getElementById(id).querySelectorAll(
             ".disable-if-inactive");
+        let elsIcon =
+          document.getElementById(id).querySelectorAll(
+            ".name-label");
         if (checked) {
           els.forEach((x) => x.removeAttribute("disabled"));
+          elsIcon.forEach((x) => x.classList.remove("fa"));
+          elsIcon.forEach((x) => x.classList.remove("fa-eye-slash"));
+          elsIcon.forEach((x) => x.classList.add("fa"));
+          elsIcon.forEach((x) => x.classList.add("fa-eye"));
         } else {
           els.forEach((x) => x.setAttribute("disabled", ""));
+          elsIcon.forEach((x) => x.classList.remove("fa"));
+          elsIcon.forEach((x) => x.classList.remove("fa-eye"));
+          elsIcon.forEach((x) => x.classList.add("fa"));
+          elsIcon.forEach((x) => x.classList.add("fa-eye-slash"));
         }
       });
     }

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
@@ -33,7 +33,7 @@ class WeightLayer {
     this.name_el.innerText = name;
     /// visible
     this.visible_el.checked = initial_visible;
-    /// view (i.e. show legend?), defaults to false
+    /// view (i.e. show legend?), defaults to true
     this.view_el.checked = true;
     /// legend
     createLegend(this.legend_el, legend, units);
@@ -55,7 +55,7 @@ class WeightLayer {
       });
     }
 
-    // set listeners to update user interfance, icons for visible checkbox
+    // set listeners to update user interface, icons for visible checkbox
     /// enable/disable widget on click
     if (HTMLWidgets.shinyMode) {
       this.visible_el.addEventListener("change", function () {
@@ -63,21 +63,10 @@ class WeightLayer {
         let els =
           document.getElementById(id).querySelectorAll(
             ".disable-if-inactive");
-        let elsIcon =
-          document.getElementById(id).querySelectorAll(
-            ".name-label");
         if (checked) {
           els.forEach((x) => x.removeAttribute("disabled"));
-          elsIcon.forEach((x) => x.classList.remove("fa"));
-          elsIcon.forEach((x) => x.classList.remove("fa-eye-slash"));
-          elsIcon.forEach((x) => x.classList.add("fa"));
-          elsIcon.forEach((x) => x.classList.add("fa-eye"));
         } else {
           els.forEach((x) => x.setAttribute("disabled", ""));
-          elsIcon.forEach((x) => x.classList.remove("fa"));
-          elsIcon.forEach((x) => x.classList.remove("fa-eye"));
-          elsIcon.forEach((x) => x.classList.add("fa"));
-          elsIcon.forEach((x) => x.classList.add("fa-eye-slash"));
         }
       });
     }

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
@@ -4,6 +4,17 @@
   border-radius: 5px 5px 5px 5px;
 }
 
-.map-manager-layer .visible-checkbox{
-  /* please insert awesome CSS code here to fix #23 */
+.map-manager-layer .visible-container input[type="checkbox"],
+.map-manager-layer .visible-container .checked {
+    display: none;
+}
+
+.map-manager-layer .visible-container input[type="checkbox"]:checked ~ .checked
+{
+    display: inline-block;
+}
+
+.map-manager-layer .visible-container input[type="checkbox"]:checked ~ .unchecked
+{
+    display: none;
 }


### PR DESCRIPTION
**This PR is for issue #23 and #24.** 

**The icons for visible checkbox (issue#23), when check box is checked, eye icon will show up, and eye slash icon will show up when checkbox is unchecked.**

<img width="517" alt="Screen Shot 2021-05-24 at 9 18 10 PM" src="https://user-images.githubusercontent.com/72098908/119428142-5af79700-bcda-11eb-8ae9-5539c3d55249.png">
<img width="517" alt="Screen Shot 2021-05-24 at 9 17 51 PM" src="https://user-images.githubusercontent.com/72098908/119428143-5af79700-bcda-11eb-86c4-c8e16044ec0b.png">

There are some backend(R) changes needed for this issue, eye icon needs to be added initially, thus an eye icon will show up initially.
<img width="517" alt="Screen Shot 2021-05-24 at 9 18 22 PM" src="https://user-images.githubusercontent.com/72098908/119428326-a742d700-bcda-11eb-8acc-45a2f3190606.png">


**The show/hide legends (issue#24), when check box is checked, legends will show up, when checkbox is unchecked legends will hide.**

<img width="518" alt="Screen Shot 2021-05-24 at 9 03 13 PM" src="https://user-images.githubusercontent.com/72098908/119428528-099bd780-bcdb-11eb-88fe-cb43c41edf05.png">
<img width="518" alt="Screen Shot 2021-05-24 at 9 02 59 PM" src="https://user-images.githubusercontent.com/72098908/119428530-0acd0480-bcdb-11eb-817d-219824b5512f.png">
<img width="518" alt="Screen Shot 2021-05-24 at 9 02 49 PM" src="https://user-images.githubusercontent.com/72098908/119428535-0b659b00-bcdb-11eb-8598-2d33a34bcabf.png">

There are some backend(R) changes needed for this issue, the "item-symbol" uses the "style" to set the background color, while hide the legends will change the "display style" to "none", which will overlap the "style" and reset the background color, just wondering is there a way to set the color (from the backend side) other than using "style"?
<img width="1356" alt="Screen Shot 2021-05-24 at 9 04 15 PM" src="https://user-images.githubusercontent.com/72098908/119428793-93e43b80-bcdb-11eb-8618-9a0bd0a37ab8.png">
