### PR TITLE
fix #22: Maximum height of theme and weight panels

### DIFF
--- a/R/solutionSettings.R
+++ b/R/solutionSettings.R
@@ -116,7 +116,7 @@ solutionSettings_html <- function(id, style, class, ...) {
           class = "solution-settings",
           shinyBS::bsCollapse(
             id = paste0(id, "_collapse"),
-            multiple = TRUE,
+            multiple = FALSE,
             open = paste0(id, c("_collapseThemePanel", "_collapseWeightPanel")),
             shinyBS::bsCollapsePanel(
               title = "Themes",

--- a/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
@@ -7,8 +7,7 @@
 .sidebar-content{
   overflow-y: hidden !important;
 }
-  
-}
+
 .new-solution-pane {
   margin-top: 3px;
 }

--- a/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/newSolutionPane-1.0.0/style.css
@@ -4,16 +4,22 @@
   padding-bottom: 2px !important;
 }
 
+.sidebar-content{
+  overflow-y: hidden !important;
+}
+  
+}
 .new-solution-pane {
   margin-top: 3px;
 }
 
 /* widget container */
 .new-solution-pane .widget-container {
-  overflow-y: auto;
+  overflow-y: hidden;
   max-height: 100%;
 }
 
 .new-solution-pane .sidebar-content {
   overflow-y: hidden !important;
 }
+

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
@@ -30,7 +30,7 @@
 }
 
 .solution-settings .panel.panel-default {
-  max-height: 42.5vh;
+  max-height: 80vh;
   overflow-y: scroll;
 }
 

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
@@ -20,6 +20,7 @@
 .solution-settings {
   flex: 3;
   display: flex;
+  max-height: 86vh;
 }
 
 .solution-settings .panel-group {


### PR DESCRIPTION
This PR is ultimately intended to update the solutionSettings widget so that (1) only one panel can be open at a time, and (2) the single panel that is open will fill up all available space in the new solution sidebar (i.e. fix https://github.com/NCC-CNC/locationmisc/issues/22). To help start this PR, I have updated the R backend such that (1) only one panel can be opened at a time (as discussed in https://github.com/NCC-CNC/locationmisc/issues/22). Could you please add additional commits to this PR to ensure that (2) the single panel that is open will fill up all available space in the sidebar?