### PR TITLE
fix #37: Animate maximizing/minimizing layers on mapManager widget

### DIFF
--- a/inst/htmlwidgets/lib/mapManager-1.0.0/MultiThemeLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/MultiThemeLayer-class.js
@@ -110,8 +110,10 @@ class MultiThemeLayer {
         let checked = this.checked;
         if (checked) {
           that.main_el.style.display = "block";
+          // TODO: insert JS to add animation for maximizing container
         } else {
           that.main_el.style.display = "none";
+          // TODO: insert JS to add animation for minimizing container
         }
       });
       /// show/hide legends
@@ -120,8 +122,10 @@ class MultiThemeLayer {
           let checked = this.checked;
           if (checked) {
             that.single_legend_el[i].style.display = "block";
+            // TODO: insert JS to add animation for maximizing legend
           } else {
             that.single_legend_el[i].style.display = "none";
+            // TODO: insert JS to add animation for minimizing legend
           }
         });
       }

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/SingleThemeLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/SingleThemeLayer-class.js
@@ -48,8 +48,10 @@ class SingleThemeLayer {
         let checked = this.checked;
         if (checked) {
           that.legend_el.style.display = "block";
+          // TODO: insert JS to add animation for maximizing legend
         } else {
           that.legend_el.style.display = "none";
+          // TODO: insert JS to add animation for minimizing legend
         }
       });
     }

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/WeightLayer-class.js
@@ -45,8 +45,10 @@ class WeightLayer {
         let checked = this.checked;
         if (checked) {
           that.legend_el.style.display = "block";
+          // TODO: insert JS to add animation for maximizing legend
         } else {
           that.legend_el.style.display = "none";
+          // TODO: insert JS to add animation for minimizing legend
         }
       });
     }


### PR DESCRIPTION
This PR is ultimately intended to update the mapManager widget so that when the [+]/[-] buttons are pressed to maximize/minimize layers, then the widget will dispay an animation of the widgets growing or shrinking to reach the maximized/minimized state. 

As discussed in our meeting today, I had a look through the JS code to add events to the [+]/[-] buttons so that function calls could be used to show the animations. When I had a closer look, it turns out that the buttons already have the events added to them. I'm sorry, I should have remembered this during our meeting. At the moment, these events have a function that updates the style for the HTML elements so that they get a `display: block` or a `display: none` style. So to implement address #37, I think this JS code could updated so that it applies a different styling that shows the animation? How des that sound? I've added comments to the JS code to show where these updates could be made (see commit https://github.com/NCC-CNC/locationmisc/commit/b2d47ee1b9866eaa4ec2b12db17a7c8b4dd8a418). 

What do you think? Is there anything else I can do to help?