### PR TITLE
Specify semi transparent colors when updating html element styles

### DIFF
--- a/inst/htmlwidgets/lib/legends-1.0.0/categoricalLegend.js
+++ b/inst/htmlwidgets/lib/legends-1.0.0/categoricalLegend.js
@@ -39,7 +39,13 @@ function categoricalLegend(el, x, units) {
     item_symbol.style.color = x.colors[i];
     if (x.colors[i].length === 9) {
       // if has alpha channel, then set opacity
-      item_symbol.style.opacity = 1 - parseInt(x.colors[i].substr(-2), 16)/255;
+      //item_symbol.style.opacity = 1 - parseInt(x.colors[i].substr(-2), 16)/255;
+      var r = parseInt(x.colors[i].slice(1, 3), 16);
+      var g = parseInt(x.colors[i].slice(3, 5), 16);
+      var b = parseInt(x.colors[i].slice(5, 7), 16);
+      var a = 1 - parseInt(x.colors[i].substr(-2), 16)/255;
+      item_symbol.style.backgroundColor = "rgba(" + r +", " + g +"," + b +", " + a +")";
+      item_symbol.style.color = "rgba(" + r +", " + g +"," + b +", " + a +")";
     }
 
     /// add item to legend

--- a/inst/htmlwidgets/lib/legends-1.0.0/categoricalLegend.js
+++ b/inst/htmlwidgets/lib/legends-1.0.0/categoricalLegend.js
@@ -37,8 +37,9 @@ function categoricalLegend(el, x, units) {
     item_symbol.className = "item-symbol disable-if-inactive";
     item_symbol.style.backgroundColor = x.colors[i];
     item_symbol.style.color = x.colors[i];
-    if(i==0){
-      item_symbol.style.opacity=0.2;
+    if (x.colors[i].length === 9) {
+      // if has alpha channel, then set opacity
+      item_symbol.style.opacity = 1 - parseInt(x.colors[i].substr(-2), 16)/255;
     }
 
     /// add item to legend

--- a/inst/htmlwidgets/lib/legends-1.0.0/categoricalLegend.js
+++ b/inst/htmlwidgets/lib/legends-1.0.0/categoricalLegend.js
@@ -37,6 +37,9 @@ function categoricalLegend(el, x, units) {
     item_symbol.className = "item-symbol disable-if-inactive";
     item_symbol.style.backgroundColor = x.colors[i];
     item_symbol.style.color = x.colors[i];
+    if(i==0){
+      item_symbol.style.opacity=0.2;
+    }
 
     /// add item to legend
     item.appendChild(item_symbol);

--- a/inst/htmlwidgets/lib/legends-1.0.0/continuousLegend.js
+++ b/inst/htmlwidgets/lib/legends-1.0.0/continuousLegend.js
@@ -50,8 +50,18 @@ function continuousLegend(el, x, units) {
   colorbar.className = "color-bar";
   let colorbar_background = "linear-gradient(180deg";
   for (let i = 0; i < x.colors.length; ++i) {
-    colorbar_background +=
+    if (x.colors[i].length === 9) {
+      // if has alpha channel, then set opacity
+      var r = parseInt(x.colors[i].slice(1, 3), 16);
+      var g = parseInt(x.colors[i].slice(3, 5), 16);
+      var b = parseInt(x.colors[i].slice(5, 7), 16);
+      var a = 1 - parseInt(x.colors[i].substr(-2), 16) / 255;
+      colorbar_background += 
+      `, rgba(${r}, ${g}, ${b}, ${a}) ${positions[i]}%`;  
+    } else {
+      colorbar_background +=
       `, ${x.colors[i]} ${positions[i]}%`;
+    }
   }
   colorbar_background += ")";
   colorbar.style.backgroundColor = x.colors[0];


### PR DESCRIPTION
The transparency has been added to the elements, it seems the #00FFFFFF been converted to #00FFFF, https://stackoverflow.com/questions/12216572/add-alpha-channel-to-a-given-color,  thus we added alpha channel by the item_symbol.style.opacity=0.2; in inst/htmlwidgets/lib/legends-1.0.0/categoricalLegend.js, please feel free to adjust the transparency value.

<img width="475" alt="Screen Shot 2021-06-14 at 9 29 03 AM" src="https://user-images.githubusercontent.com/72098908/121908403-f9d04b80-ccfa-11eb-9444-6c456b92aad9.png">
