### PR TITLE
Changed to 'upload shapefile' , fix #199

### DIFF
--- a/R/ui_importModal.R
+++ b/R/ui_importModal.R
@@ -73,7 +73,7 @@ importModal <- function(id) {
       choices = c(
         "built-in project" = "builtin",
         "upload project data" = "manual",
-        "spatial dataset" = "spatial"
+        "upload shapefile" = "spatial"
       ),
       selected = "built-in project",
       multiple = FALSE


### PR DESCRIPTION
Changed "spatial dataset" label from the select drop-down menu widget to "upload shapefile"