### PR TITLE
(hide/show) view container only for multi theme

### DIFF
--- a/inst/htmlwidgets/lib/mapManager-1.0.0/MultiThemeLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/MultiThemeLayer-class.js
@@ -36,6 +36,9 @@ class MultiThemeLayer {
     this.name_el = this.el.querySelector(".name-label");
     this.main_el = this.el.querySelector(".main");
 
+    // enable view container only for multi theme layers
+    this.el.querySelector(".view-container").style.display = 'inline-block';
+
     // local variables
     const that = this;
 

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/categoricalLegend.css
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/categoricalLegend.css
@@ -8,7 +8,7 @@
   flex-flow: row wrap;
   align-content: flex-end;
   margin: 0px;
-  margin-left:23px;
+  margin-left:10px;
 }
 
 .categorical-legend .item {

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/continuousLegend.css
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/continuousLegend.css
@@ -2,7 +2,7 @@
 .continuous-legend {
   display: flex;
   flex-direction: column;
-  padding: 3px 0px 3px 20px;
+  padding: 3px 0px 3px 10px;
 }
 
 .continuous-legend-plus {

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/manualLegend.css
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/manualLegend.css
@@ -8,7 +8,7 @@
   flex-flow: row wrap;
   align-content: flex-end;
   margin: 0px;
-  margin-left:23px;
+  margin-left:10px;
 }
 
 .manual-legend .item {

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
@@ -112,6 +112,10 @@
     display: none;
 }
 
+.map-manager-layer .view-container
+{
+    display: none;
+}
 
 /* visible checkbox */
 .map-manager-layer .visible-container input[type="checkbox"],


### PR DESCRIPTION
(sorry for the previous PR #231, it was in the incorrect branch)
Minor UI changes in the left sidebar removing the button to hide/show legend and only enabling it (view container button) for multi-theme layers. IMO has several buttons to hide 23 or 47px of vertical space don't have much sense, removing the buttons from single layers reduces the UI elements and improves usability. (maybe a final implementation of this requires cleaning some JS codes)

![Screenshot_20220822_124753](https://user-images.githubusercontent.com/11801453/186014777-32894262-591b-4c8f-9656-b2d995fe892f.png)

