### PR TITLE
Adjuste vertical overflow scroll for left and right sidebar for multi-layers container

### DIFF
--- a/inst/htmlwidgets/lib/mapManager-1.0.0/MultiThemeLayer-class.js
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/MultiThemeLayer-class.js
@@ -147,11 +147,9 @@ class MultiThemeLayer {
       this.view_el.addEventListener("change", function () {
         const checked = this.checked;
         if (checked) {
-          that.main_el.style.display = "block";
-          // TODO: insert JS to add animation for maximizing container
+          that.main_el.style.maxHeight = "45vh";
         } else {
-          that.main_el.style.display = "none";
-          // TODO: insert JS to add animation for minimizing container
+          that.main_el.style.maxHeight = "0vh";
         }
       });
       /// show/hide legends

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
@@ -72,6 +72,11 @@
   margin-bottom: 5px;
 }
 
+.map-manager-layer .main {
+  overflow-y: auto;
+  max-height: 45vh;
+}
+
 /* sub-header container */
 .map-manager-layer .sub-header {
   display: flex;

--- a/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/mapManager-1.0.0/style.css
@@ -75,6 +75,7 @@
 .map-manager-layer .main {
   overflow-y: auto;
   max-height: 45vh;
+  transition:all .4s ease;
 }
 
 /* sub-header container */

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/MultiThemeSetting-class.js
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/MultiThemeSetting-class.js
@@ -382,24 +382,23 @@ class MultiThemeSetting {
           });
         }
       });
-
+      /// tab
+      this.single_tab_el.addEventListener("click", function() {
+        Shiny.setInputValue(manager, {
+          id: id,
+          setting: "status",
+          value: that.single_status_values,
+          type: "feature_status"
+        });
+        Shiny.setInputValue(manager, {
+          id: id,
+          setting: "feature_goal",
+          value: that.single_goal_values,
+          type: "theme"
+        });
+      });
       /// single view
       for (let i = 0; i < this.n_features; ++i) {
-        /// tab
-        this.single_tab_el.addEventListener("click", function() {
-          Shiny.setInputValue(manager, {
-            id: id,
-            setting: "status",
-            value: that.single_status_values,
-            type: "feature_status"
-          });
-          Shiny.setInputValue(manager, {
-            id: id,
-            setting: "feature_goal",
-            value: that.single_goal_values,
-            type: "theme"
-          });
-        });
         /// status
         this.single_status_el[i].addEventListener("change", function() {
           that.single_status_values[i] = that.single_status_el[i].checked;

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
@@ -163,7 +163,7 @@
 
 .solution-setting .single-view {
   overflow-y: auto;
-  max-height: 150px;
+  max-height: 36vh;
 }
 
 .solution-setting .main {


### PR DESCRIPTION
Two changes:
* vertical overflow scroll a bit larger and dynamic using `vh` for the multi-layers container in the right sidebar
* Added vertical overflow scroll for the multi-layers container in the left sidebar 

![Screenshot_20220825_193944](https://user-images.githubusercontent.com/11801453/186806138-2099b56b-2a57-4bbb-866f-e152659fb14c.png)
![Screenshot_20220825_194007](https://user-images.githubusercontent.com/11801453/186806155-c502d990-301e-4d73-8669-c117dd72c369.png)

