### PR TITLE
Removing pryr library

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
     stringi (>= 1.7.3),
     tools (>= 4.0.5),
     Matrix (>= 1.3-3),
-    pryr (>= 0.1.4),
     uuid (>= 0.1.4),
     scales (>= 1.1.1),
     units (>= 0.7.2),

--- a/R/app_global.R
+++ b/R/app_global.R
@@ -6,7 +6,7 @@ app_global <- quote({
   if (isTRUE(wheretowork::get_golem_config("monitor"))) {
       cli::cli_rule()
       golem::print_dev("Initial memory used: ")
-      golem::print_dev(pryr::mem_used())
+      golem::print_dev(mem_used())
   }
 
   # initialize file upload limits

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -15,9 +15,9 @@ app_server <- function(input, output, session) {
       shiny::invalidateLater(3000)
       cli::cli_rule()
       golem::print_dev("Total memory used: ")
-      golem::print_dev(pryr::mem_used())
+      golem::print_dev(mem_used())
       golem::print_dev("  app_data")
-      golem::print_dev(pryr::object_size(app_data))
+      golem::print_dev(object_size(app_data))
     })
   }
 

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -17,7 +17,7 @@ app_server <- function(input, output, session) {
       golem::print_dev("Total memory used: ")
       golem::print_dev(mem_used())
       golem::print_dev("  app_data")
-      golem::print_dev(object_size(app_data))
+      golem::print_dev(object.size(app_data))
     })
   }
 

--- a/renv.lock
+++ b/renv.lock
@@ -911,13 +911,6 @@
       "Repository": "CRAN",
       "Hash": "50b405c6419e921b9e9360cc9ebbcf2d"
     },
-    "pryr": {
-      "Package": "pryr",
-      "Version": "0.1.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "3fb39bed6e21e21cdb79a3203c6a198e"
-    },
     "ps": {
       "Package": "ps",
       "Version": "1.6.0",


### PR DESCRIPTION
Hi all, this is a minor PR:

Pryr is deprecated and no longer available for the new R versions, and also it is not necessary because the functions used are availables by other libs:

- _mem_used()_ provider by lobstr
- _object_size()_ migrate to _object.size_ from utils library