### PR TITLE
fix bug in calculate_coverage()

### DIFF
--- a/R/utils_spatial_misc.R
+++ b/R/utils_spatial_misc.R
@@ -78,12 +78,12 @@ repair_spatial_data <- function(x) {
 #'   available (see Details for more information)
 #'
 #' @return A `numeric` vector containing the total area of each reserve.
-#' 
+#'
 #' @details For spatial uploads (shapefile) with many planning units, building
-#'   boundary data can result in a std::bad_alloc error. To avoid this, the 
-#'   user can skip generating a boundary matrix on the `new_dataset_from_auto` 
-#'   method. For these scenarios, reserve sizes can not be calculated when the 
-#'   `boundary_matrix` is set to `NA`.  
+#'   boundary data can result in a std::bad_alloc error. To avoid this, the
+#'   user can skip generating a boundary matrix on the `new_dataset_from_auto`
+#'   method. For these scenarios, reserve sizes can not be calculated when the
+#'   `boundary_matrix` is set to `NA`.
 #'
 #' @export
 reserve_sizes <- function(x, areas, boundary_matrix) {
@@ -99,7 +99,7 @@ reserve_sizes <- function(x, areas, boundary_matrix) {
     ## boundary matrix
     inherits(boundary_matrix, c("dsCMatrix", "dgCMatrix", "logical")))
   if (inherits(boundary_matrix, c("dsCMatrix", "dgCMatrix"))) {
-    assertthat::assert_that(    
+    assertthat::assert_that(
       nrow(boundary_matrix) == ncol(boundary_matrix),
       nrow(boundary_matrix) == length(x)
     )
@@ -109,7 +109,7 @@ reserve_sizes <- function(x, areas, boundary_matrix) {
   if (!inherits(boundary_matrix, c("dsCMatrix", "dgCMatrix"))) {
     return(NA_real_)
   }
-  
+
   # return NA if no planning units selected, then return NA
   if (sum(x) < 0.5) {
     return(NA_real_)
@@ -170,6 +170,7 @@ calculate_coverage <- function(x, data) {
     )
     out <- as.numeric(data %*% out) / Matrix::rowSums(data)
     names(out) <- rownames(data)
+    out[!is.finite(out)] <- 0
   } else {
     out <- numeric(0)
   }


### PR DESCRIPTION
Hi @DanWismer,

I got an email about the WTW tool crashing when a user was trying to upload a shapefile. It turned out some of their columns in the attribute table only had zero; which caused a divide by zero calculation; resulting in NaN values for certain variables that shouldn't have NA values; and, in turn, crashing the app. This PR fixes the bug and means the app should now work with features that only contain zeros. When you get a chance, could you please review it and merge into the mian branch? Although the fix is super minor - I don't want to cause any merge issues with the stuff you've been working on, so I thought it best not to merge immediately. Let me know if you have any questions?
 