### PR TITLE
issue 327 fix download when PUs are sf

### DIFF
--- a/R/server_export_data.R
+++ b/R/server_export_data.R
@@ -110,7 +110,7 @@ server_export_data <- quote({
       }
       # save spatial data
       write_spatial_data(
-        x = terra::rast(d),
+        x = d,
         dir = td,
         name = "data"
       )

--- a/R/utils_spatial_io.R
+++ b/R/utils_spatial_io.R
@@ -87,7 +87,7 @@ write_spatial_data <- function(x, dir, name) {
     ## save raster data in GeoTIFF format
     suppressWarnings({
       writeNamedRaster(
-        x = x, filename = file.path(dir, paste0(name, ".tif")),
+        x = terra::rast(x), filename = file.path(dir, paste0(name, ".tif")),
         overwrite = TRUE, NAflag = -9999
       )
     })

--- a/R/utils_spatial_io.R
+++ b/R/utils_spatial_io.R
@@ -63,7 +63,7 @@ read_spatial_data <- function(x) {
 #' # read and write raster data
 #' f1 <- system.file("external/rlogo.grd", package = "raster")
 #' d1 <- read_spatial_data(f1)
-#' write_spatial_data(terra::rast(d1), tempdir(), "rlogo")
+#' write_spatial_data(d1, tempdir(), "rlogo")
 #'
 #' # read and write vector data
 #' f2 <- system.file("shape/nc.shp", package = "sf")
@@ -73,7 +73,7 @@ read_spatial_data <- function(x) {
 #' @export
 write_spatial_data <- function(x, dir, name) {
   assertthat::assert_that(
-    inherits(x, c("sf", "SpatRaster")),
+    inherits(x, c("sf", "Raster")),
     assertthat::is.string(dir),
     assertthat::noNA(dir),
     assertthat::is.string(name),

--- a/man/write_spatial_data.Rd
+++ b/man/write_spatial_data.Rd
@@ -23,7 +23,7 @@ Write spatial data to disk.
 # read and write raster data
 f1 <- system.file("external/rlogo.grd", package = "raster")
 d1 <- read_spatial_data(f1)
-write_spatial_data(terra::rast(d1), tempdir(), "rlogo")
+write_spatial_data(d1, tempdir(), "rlogo")
 
 # read and write vector data
 f2 <- system.file("shape/nc.shp", package = "sf")

--- a/tests/testthat/test_write_spatial_data.R
+++ b/tests/testthat/test_write_spatial_data.R
@@ -18,8 +18,6 @@ test_that("vector data", {
 test_that("raster data", {
   # create dataset
   d <- simulate_proportion_spatial_data(import_simple_raster_data(), 3)
-  # convert to SpatRaster
-  d <- terra::rast(d)
   # save data
   write_spatial_data(d, dir = tempdir(), name = "data2")
   # run tests


### PR DESCRIPTION
Moved `terra::rast()` call into `write_spatial_data()`.

Fixes error where download failed because `server_export_data.R` was attempting to convert the sf object to a `SpatRaster`.

The error in this case was not crashing the app, the download widget within the browser was throwing an error and not exporting the .zip.

closes #327 