### PR TITLE
updated multi-theme tabs, #fix 244

### DIFF
--- a/R/widget_solutionSettings_ui.R
+++ b/R/widget_solutionSettings_ui.R
@@ -445,14 +445,16 @@ solutionSettings_html <- function(id, style, class, ...) {
               id = "view",
               ## single view
               shiny::tabPanel(
-                "single",
+                title = "optimize single goals",
+                value = "single",
                 htmltools::tags$div(
                   class = "single-view"
                 )
               ),
               ## group view panel
               shiny::tabPanel(
-                "group",
+                title = "optimize group goal",
+                value = "group",
                 htmltools::tags$div(
                   class = "group-view",
                   ss_group_goal_component_scaffold()

--- a/R/widget_solutionSettings_ui.R
+++ b/R/widget_solutionSettings_ui.R
@@ -443,6 +443,13 @@ solutionSettings_html <- function(id, style, class, ...) {
             shiny::tabsetPanel(
               type = "tabs",
               id = "view",
+              ## single view
+              shiny::tabPanel(
+                "single",
+                htmltools::tags$div(
+                  class = "single-view"
+                )
+              ),
               ## group view panel
               shiny::tabPanel(
                 "group",
@@ -450,14 +457,7 @@ solutionSettings_html <- function(id, style, class, ...) {
                   class = "group-view",
                   ss_group_goal_component_scaffold()
                 )
-              ),
-              ## single view
-              shiny::tabPanel(
-                "single",
-                htmltools::tags$div(
-                  class = "single-view"
-                )
-              )
+              )              
             )
           )
         )

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/MultiThemeSetting-class.js
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/MultiThemeSetting-class.js
@@ -134,15 +134,15 @@ class MultiThemeSetting {
     this.el
       .querySelector(".tabbable .tab-content")
       .setAttribute("data-tabsetid", `tabs-${this.elementId}`);
-    /// group tab
-    this.group_tab_el.setAttribute("href", `#tabs-${this.elementId}-1`);
-    this.el
-      .querySelector(".tabbable .tab-content [data-value='group']")
-      .setAttribute("id", `tabs-${this.elementId}-1`);
     /// single tab
-    this.single_tab_el.setAttribute("href", `#tabs-${this.elementId}-2`);
+    this.single_tab_el.setAttribute("href", `#tabs-${this.elementId}-1`);
     this.el
       .querySelector(".tabbable .tab-content [data-value='single']")
+      .setAttribute("id", `tabs-${this.elementId}-1`);      
+    /// group tab
+    this.group_tab_el.setAttribute("href", `#tabs-${this.elementId}-2`);
+    this.el
+      .querySelector(".tabbable .tab-content [data-value='group']")
       .setAttribute("id", `tabs-${this.elementId}-2`);
 
     // set initial theme values

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/MultiThemeSetting-class.js
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/MultiThemeSetting-class.js
@@ -29,7 +29,7 @@ class MultiThemeSetting {
     this.single_limit_values = feature_limit_goal;
     this.units = units;
     this.group_limit_goal = Math.max.apply(Math, feature_limit_goal);
-    this.previous_group_goal = Math.max.apply(Math, feature_goal);
+    this.previous_group_goal = 0.2 // set group goal at 20% when app inits
     this.previous_single_goals = [...feature_goal];
 
     /// HTML container
@@ -162,7 +162,7 @@ class MultiThemeSetting {
       Math.max.apply(Math, feature_current_held));
     /// slider
     noUiSlider.create(this.group_goal_el, {
-      start: Math.max.apply(Math, feature_goal),
+      start: 0.2, // set group goal at 20% when app inits
       step: Math.min.apply(Math, feature_step_goal),
       connect: "lower",
       range: {
@@ -270,7 +270,7 @@ class MultiThemeSetting {
         //// reset status
         that.updateFeatureStatus(feature_status);
         /// reset goals
-        that.updateGroupGoal(Math.max.apply(Math, feature_goal));
+        that.updateGroupGoal(0.2); // reset group goal to 20%
         that.updateFeatureGoal(feature_goal);
         /// pass status data to Shiny
         Shiny.setInputValue(manager, {

--- a/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
+++ b/inst/htmlwidgets/lib/solutionSettings-1.0.0/style.css
@@ -482,3 +482,9 @@ input[type="file"].input_config {
   margin-top: -25px;
   margin-left: 5px;
 }
+
+/* active goal tab (single / group) */
+#view .active a {
+  background-color: #118ab2;
+  color: #fff;
+}


### PR DESCRIPTION
- changed tab names (ex. "single" changed to "optimize single goals")
- single goals appear first and are active when app spins up
- group goals are hard-coded to 20% when app spins up
- refresh group goals is hard-coded to 20%
- updated active tab style