### PR TITLE
increase future.globals.maxSize to 1GB, fix #352

### DIFF
--- a/R/app_global.R
+++ b/R/app_global.R
@@ -11,6 +11,8 @@ app_global <- quote({
 
   # initialize file upload limits
   options(shiny.maxRequestSize = 1000*1024^2) # 1GB
+  # set global variables limit for future package
+  options(future.globals.maxSize= 1000*1024^2) # 1GB
 
   # initialize asynchronous processing
   ## identify strategy


### PR DESCRIPTION
default is 500MB. This would crash the app for a WTW project the size of SK.