### PR TITLE
Adjust the tooltip position of the solution charts if the tooltip width goes out of the max X window width

### DIFF
--- a/inst/htmlwidgets/lib/solutionResults-1.0.0/IncludeSolutionChart-class.js
+++ b/inst/htmlwidgets/lib/solutionResults-1.0.0/IncludeSolutionChart-class.js
@@ -90,7 +90,7 @@ class IncludeSolutionChart {
         const tooltipWidth = tooltip.node().getBoundingClientRect().width;
         const windowWidth = window.innerWidth;
         if (e.clientX + 5 + tooltipWidth > windowWidth) {
-          tooltip.style("left", `${windowWidth - tooltipWidth - 5}px`);
+          tooltip.style("left", `${windowWidth - tooltipWidth}px`);
         }
       })
       .on("mouseout", function() {

--- a/inst/htmlwidgets/lib/solutionResults-1.0.0/IncludeSolutionChart-class.js
+++ b/inst/htmlwidgets/lib/solutionResults-1.0.0/IncludeSolutionChart-class.js
@@ -86,6 +86,12 @@ class IncludeSolutionChart {
           .style("top", `${e.clientY + 5}px`)
           .style("left", `${e.clientX + 5}px`);
         self.showStats(d, tooltip, type)
+        // adjust the tooltip position if the tooltip width goes out of the max X window width
+        const tooltipWidth = tooltip.node().getBoundingClientRect().width;
+        const windowWidth = window.innerWidth;
+        if (e.clientX + 5 + tooltipWidth > windowWidth) {
+          tooltip.style("left", `${windowWidth - tooltipWidth - 5}px`);
+        }
       })
       .on("mouseout", function() {
         d3

--- a/inst/htmlwidgets/lib/solutionResults-1.0.0/ThemeSolutionChart-class.js
+++ b/inst/htmlwidgets/lib/solutionResults-1.0.0/ThemeSolutionChart-class.js
@@ -178,7 +178,7 @@ class ThemeSolutionChart {
           const tooltipWidth = tooltip.node().getBoundingClientRect().width;
           const windowWidth = window.innerWidth;
           if (e.clientX + 5 + tooltipWidth > windowWidth) {
-            tooltip.style("left", `${windowWidth - tooltipWidth - 5}px`);
+            tooltip.style("left", `${windowWidth - tooltipWidth}px`);
           }
         })
         .on("mouseout", function() {

--- a/inst/htmlwidgets/lib/solutionResults-1.0.0/ThemeSolutionChart-class.js
+++ b/inst/htmlwidgets/lib/solutionResults-1.0.0/ThemeSolutionChart-class.js
@@ -174,6 +174,12 @@ class ThemeSolutionChart {
             d.find((x) => x[0] === "feature_solution_held"),
             tooltip,
             type);
+          // adjust the tooltip position if the tooltip width goes out of the max X window width
+          const tooltipWidth = tooltip.node().getBoundingClientRect().width;
+          const windowWidth = window.innerWidth;
+          if (e.clientX + 5 + tooltipWidth > windowWidth) {
+            tooltip.style("left", `${windowWidth - tooltipWidth - 5}px`);
+          }
         })
         .on("mouseout", function() {
           d3

--- a/inst/htmlwidgets/lib/solutionResults-1.0.0/WeightSolutionChart-class.js
+++ b/inst/htmlwidgets/lib/solutionResults-1.0.0/WeightSolutionChart-class.js
@@ -105,7 +105,7 @@ class WeightSolutionChart {
         const tooltipWidth = tooltip.node().getBoundingClientRect().width;
         const windowWidth = window.innerWidth;
         if (e.clientX + 5 + tooltipWidth > windowWidth) {
-          tooltip.style("left", `${windowWidth - tooltipWidth - 5}px`);
+          tooltip.style("left", `${windowWidth - tooltipWidth}px`);
         }
       })
       .on("mouseout", function() {

--- a/inst/htmlwidgets/lib/solutionResults-1.0.0/WeightSolutionChart-class.js
+++ b/inst/htmlwidgets/lib/solutionResults-1.0.0/WeightSolutionChart-class.js
@@ -101,6 +101,12 @@ class WeightSolutionChart {
           .style("top", `${e.clientY + 5}px`)
           .style("left", `${e.clientX + 5}px`);
         self.showStats(d, tooltip, type)
+        // adjust the tooltip position if the tooltip width goes out of the max X window width
+        const tooltipWidth = tooltip.node().getBoundingClientRect().width;
+        const windowWidth = window.innerWidth;
+        if (e.clientX + 5 + tooltipWidth > windowWidth) {
+          tooltip.style("left", `${windowWidth - tooltipWidth - 5}px`);
+        }
       })
       .on("mouseout", function() {
         d3


### PR DESCRIPTION
Special cases when features, weights or includes/excludes have long names without spaces:

Before:
![image](https://github.com/user-attachments/assets/d7a48f91-9c67-4484-8ec1-c738f7146841)
 
After:
![image](https://github.com/user-attachments/assets/b23e804d-91ce-42a2-8376-d6a607d70fe1)

