### PR TITLE
Improving the style of the boxes for solution layers in order to identify it from other layers

### DIFF
--- a/inst/htmlwidgets/solutionSettings.css
+++ b/inst/htmlwidgets/solutionSettings.css
@@ -10,3 +10,8 @@
   --border: black;
   --symbol-border: #D3D3D3;
 }
+
+/* background color for solution layers in order to identify it from other layers */
+div:has(> div.solution-layer) {
+  background-color: #e9ecef;
+}


### PR DESCRIPTION
Hi guys

It's just an idea, no problem if you don't like it or want to change it.

The problem is that originally the solution layers are loaded with the same style as layers, the only way to identify a solution layer is through the icons in the corner, but users may find it difficult to identify them:

![Screenshot_20241211_093111](https://github.com/user-attachments/assets/6ee8dd8d-7524-4652-82b5-ca0b439351dd)

My idea, and in order to improve the usability, is changing the style of the boxes for solution layers in order to identify it from other layers. Adding a background could be enough, I'm using the light grey used as a background in the groups in "new solution" widget. Of course, I'm open to changing the color or doing something different to identify solution layers from others. (the legend "not selected" should be white?)

![image](https://github.com/user-attachments/assets/6ebc75a7-6d92-4105-af82-803d4b1da38e)
