### PR TITLE
partner groups should only see their own built-in projects

### DIFF
--- a/.github/workflows/R-CMD-check-ubuntu.yaml
+++ b/.github/workflows/R-CMD-check-ubuntu.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get -y install libcurl4-openssl-dev coinor-libsymphony-dev coinor-libcbc-dev coinor-libclp-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev libharfbuzz-dev libfribidi-dev libuv1-dev
+          sudo apt-get -y install libcurl4-openssl-dev coinor-libsymphony-dev coinor-libcbc-dev coinor-libclp-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev libharfbuzz-dev libfribidi-dev libuv1-dev libglpk-dev
 
       - name: Install dependencies
         run: |

--- a/R/app_global.R
+++ b/R/app_global.R
@@ -65,8 +65,13 @@ app_global <- quote({
 
   user_groups <- strsplit(user_groups, ",", fixed = TRUE)[[1]]
 
-  # ensure that public projects are always available
-  user_groups <- unique(c("public", user_groups))
+  # ensure that public projects are always available,
+  # except for partner groups that should only see their own projects
+  # (admin membership still grants access to everything via find_projects())
+  exclusive_groups <- c("iamgold")
+  if (!any(exclusive_groups %in% user_groups)) {
+    user_groups <- unique(c("public", user_groups))
+  }
 
   # set project data directory
   if (identical(Sys.getenv("FORCE_DEFAULT_PROJECTS"), "true")) {


### PR DESCRIPTION
Adds an `exclusive_groups` allowlist in `R/app_global.R` so partner orgs skip the auto-injection of `public`, restricting them to their own built-in projects.
